### PR TITLE
26 memory management server socket

### DIFF
--- a/headers/Server.hpp
+++ b/headers/Server.hpp
@@ -17,6 +17,7 @@ class Server {
 		void updatePollFdForWrite(int fd);
 		void updatePollFdForRead(int fd);
 		void addServerConfig(ServerDirectives& serverConfig);
+        void closeServer(void);
 		// whichconfig(host name from request)
 	private:
 		const int _client_max_body_size;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -8,10 +8,22 @@ Server::Server(ServerDirectives& inputConfig, size_t client_max_body_size) : _cl
     // LOG_INFO_NAME("Constructor called. Server starting...", input_config->_directives[translateDirectives(SERVERNAME)][0]);
     addListeningSocket();
 }
+Server::~Server() {
+}
 
-
-Server::~Server() {}
-
+void Server::closeServer(void){
+    LOG_DEBUG_NAME("Close Server Socket Map.", _server_config[0].server_name);
+    std::map<int, Socket*>::iterator it;
+    for (it = _socket_map.begin(); it != _socket_map.end(); ++it) {
+        if (it->second != NULL) {
+            delete it->second;
+            it->second = NULL;
+        }
+    }
+    _socket_map.clear();
+    _poll_fd_vector.clear();
+    LOG_DEBUG_NAME("Server Socket Map cleaned up.", _server_config[0].server_name);
+}
 
 void Server::addServerConfig(ServerDirectives& serverConfig){
     _server_config.push_back(serverConfig);

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -1,6 +1,6 @@
 #include "Socket.hpp"
 
-Socket::Socket(std::string& listen_port) : _listen_port(listen_port), _sockfd(-1), _http_request(NULL){
+Socket::Socket(std::string& listen_port) : _listen_port(listen_port), _sockfd(-1), _http_request(NULL), _http_response(NULL){
 	_socket_type = SERVER;
 	setSocketStatus(LISTEN_STATE);
 	LOG_DEBUG("Constructor for listening Socket called.");
@@ -15,18 +15,28 @@ Socket::Socket(std::string& listen_port) : _listen_port(listen_port), _sockfd(-1
 }
 
 // Socket::Socket(int connection_fd) : socket_config(NULL), _sockfd(connection_fd), _addr_info(NULL), _http_request(NULL) {
-Socket::Socket(int connection_fd) : _sockfd(connection_fd), _addr_info(NULL), _http_request(NULL) {
+Socket::Socket(int connection_fd) : _sockfd(connection_fd), _addr_info(NULL), _http_request(NULL), _http_response(NULL) {
 	_socket_type = CLIENT;
 	setSocketStatus(RECEIVE);
 }
-
+// Socket::~Socket() {
+//     LOG_DEBUG("Socket Destructor called.");
+// }
 Socket::~Socket() {
+	LOG_DEBUG("Socket Destructor called.");
 	removeSocket();
 	if (_addr_info != NULL) {
 		freeaddrinfo(_addr_info);
 		LOG_DEBUG("Address info freed.");
 	}
-	LOG_DEBUG("Socket destroyed.");
+    if (_http_request != NULL) {
+        delete _http_request;
+        LOG_DEBUG("HTTP Request freed.");
+    }
+    if (_http_response != NULL) {
+        delete _http_response;
+        LOG_DEBUG("HTTP Response freed.");
+    }
 }
 
 bool Socket::setupAddrInfo() {

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -19,9 +19,7 @@ Socket::Socket(int connection_fd) : _sockfd(connection_fd), _addr_info(NULL), _h
 	_socket_type = CLIENT;
 	setSocketStatus(RECEIVE);
 }
-// Socket::~Socket() {
-//     LOG_DEBUG("Socket Destructor called.");
-// }
+
 Socket::~Socket() {
 	LOG_DEBUG("Socket Destructor called.");
 	removeSocket();

--- a/src/Webserv.cpp
+++ b/src/Webserv.cpp
@@ -14,6 +14,10 @@ Webserv::Webserv(char* str){
 	}
 }
 Webserv::~Webserv(){
+    LOG_DEBUG("Webserv Destructor called.");
+    for (size_t i = 0; i < _servers.size(); ++i){
+        _servers[i].closeServer();
+    }
 }
 
 void Webserv::init_servers() {


### PR DESCRIPTION
closes #26 
Ctrl-c calls the webserv destructor, which calls the clearServer function of all servers. Those functions then free the memory allocated from the sockets